### PR TITLE
build(actions): update docker bake-action to v6 and add build file check

### DIFF
--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -150,14 +150,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -149,14 +149,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -165,14 +165,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -163,14 +163,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -150,14 +150,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -149,14 +149,22 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows/docker-buildx-bake-multi-latest.yml
@@ -165,14 +165,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/.github/workflows/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows/docker-buildx-bake-multi-tag.yml
@@ -163,14 +163,22 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: check build files
+        run: |
+          echo "docker_bake_config_file_path: ${{ inputs.docker_bake_config_file_path }}"
+          ls -al ${{ runner.temp }}/${{ inputs.docker_bake_targets}}
+          echo "show: ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json"
+          cat ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+
+      -
         name: Build
         id: bake
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
-            ${{ inputs.docker_bake_config_file_path }}
-            ${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
+            cwd://${{ inputs.docker_bake_config_file_path }}
+            cwd://${{ runner.temp }}/${{ inputs.docker_bake_targets}}/bake-meta.json
           targets: ${{ inputs.docker_bake_targets }}
           no-cache: ${{ inputs.docker-build-no-cache }}
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/lord-of-dock/docker-net-tools"
 
 # https://hub.docker.com/_/alpine/tags

--- a/build-alpine.dockerfile
+++ b/build-alpine.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/bridgewwater/template-docker-runtime-alpine"
 
 # https://hub.docker.com/_/alpine/tags

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile uses extends image https://hub.docker.com/_/alpine
 # VERSION 1
 # Author: sinlov
-# dockerfile offical document https://docs.docker.com/engine/reference/builder/
+# dockerfile official document https://docs.docker.com/engine/reference/builder/
 # maintainer="https://github.com/lord-of-dock/docker-net-tools"
 
 # https://hub.docker.com/_/alpine/tags


### PR DESCRIPTION
feat #4

- Update docker/bake-action from v5 to v6 in multiple workflow files
- Add a new step to check build files before running docker bake
- Update file paths to use cwd:// prefix for better clarity
- Minor typo corrections in Dockerfile comments