### PR TITLE
build(ci): update GitHub release action to v2

### DIFF
--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           ls -R ${{ github.workspace }}/dist
 
-      - uses: softprops/action-gh-release@master
+      - uses: softprops/action-gh-release@v2
         name: Create Release
         if: ${{ ! inputs.dry_run }}
         with:


### PR DESCRIPTION
- Update softprops/action-gh-release from master to v2
- Ensures the use of a specific version for consistency and stability
